### PR TITLE
feat: group dashboard sections by media type with Next Up priority

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import Link from "next/link";
 import { MediaCard } from "@/components/media/MediaCard";
+import { SetNextUpButton } from "@/components/media/SetNextUpButton";
 import { Button } from "@/components/ui/button";
 import { Plus, Sparkles } from "lucide-react";
 import { MEDIA_TYPE_LABELS, MEDIA_TYPE_ICONS } from "@/lib/utils";
@@ -10,20 +11,135 @@ export const metadata = { title: "Dashboard" };
 
 const MEDIA_TYPES = ["MOVIE", "TV_SHOW", "BOOK", "AUDIOBOOK", "VIDEO_GAME"];
 
+type EntryWithMedia = Awaited<ReturnType<typeof fetchEntries>>[number];
+
+async function fetchEntries(userId: string) {
+  return db.mediaEntry.findMany({
+    where: { userId },
+    include: { mediaItem: true },
+    orderBy: [{ sortOrder: "asc" }, { updatedAt: "desc" }],
+  });
+}
+
+function groupByType(entries: EntryWithMedia[]) {
+  const groups: Record<string, EntryWithMedia[]> = {};
+  for (const entry of entries) {
+    const type = entry.mediaItem.type;
+    if (!groups[type]) groups[type] = [];
+    groups[type].push(entry);
+  }
+  return groups;
+}
+
+interface TypeGroupProps {
+  type: string;
+  entries: EntryWithMedia[];
+  showNextUp?: boolean;
+}
+
+function TypeGroup({ type, entries, showNextUp }: TypeGroupProps) {
+  if (entries.length === 0) return null;
+  const icon = MEDIA_TYPE_ICONS[type] ?? "📦";
+  const label = MEDIA_TYPE_LABELS[type] ?? type;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-base">{icon}</span>
+        <h3 className="text-sm font-semibold text-zinc-600 uppercase tracking-wide">{label}</h3>
+        <div className="flex-1 border-t border-zinc-100" />
+        <span className="text-xs text-zinc-400">{entries.length}</span>
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        {entries.map((entry, idx) => (
+          <div key={entry.id} className="flex flex-col gap-1">
+            <MediaCard
+              id={entry.mediaItem.id}
+              title={entry.mediaItem.title}
+              year={entry.mediaItem.year}
+              posterUrl={entry.mediaItem.posterUrl}
+              mediaType={entry.mediaItem.type}
+              status={entry.status}
+              rating={entry.rating}
+            />
+            {showNextUp && (
+              <div className="flex justify-center">
+                <SetNextUpButton entryId={entry.id} isNextUp={idx === 0} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface DashboardSectionProps {
+  title: string;
+  entries: EntryWithMedia[];
+  showNextUp?: boolean;
+}
+
+function DashboardSection({ title, entries, showNextUp }: DashboardSectionProps) {
+  if (entries.length === 0) return null;
+  const groups = groupByType(entries);
+  const activeTypes = MEDIA_TYPES.filter((t) => (groups[t]?.length ?? 0) > 0);
+  const hasMultipleTypes = activeTypes.length > 1;
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-zinc-900 mb-4">{title}</h2>
+      <div className={hasMultipleTypes ? "flex flex-col gap-8" : ""}>
+        {activeTypes.map((type) => (
+          hasMultipleTypes ? (
+            <TypeGroup
+              key={type}
+              type={type}
+              entries={groups[type]}
+              showNextUp={showNextUp}
+            />
+          ) : (
+            <div
+              key={type}
+              className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6"
+            >
+              {groups[type].map((entry, idx) => (
+                <div key={entry.id} className="flex flex-col gap-1">
+                  <MediaCard
+                    id={entry.mediaItem.id}
+                    title={entry.mediaItem.title}
+                    year={entry.mediaItem.year}
+                    posterUrl={entry.mediaItem.posterUrl}
+                    mediaType={entry.mediaItem.type}
+                    status={entry.status}
+                    rating={entry.rating}
+                  />
+                  {showNextUp && (
+                    <div className="flex justify-center">
+                      <SetNextUpButton entryId={entry.id} isNextUp={idx === 0} />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export default async function DashboardPage() {
   const session = await auth();
   if (!session) return null;
 
-  const entries = await db.mediaEntry.findMany({
-    where: { userId: session.user.id },
-    include: { mediaItem: true },
-    orderBy: { updatedAt: "desc" },
-  });
+  const entries = await fetchEntries(session.user.id);
 
   const inProgress = entries.filter((e) => e.status === "IN_PROGRESS");
+  const wantEntries = entries.filter((e) => e.status === "WANT");
   const recentCompleted = entries
     .filter((e) => e.status === "COMPLETED")
-    .slice(0, 10);
+    .slice(0, 12);
 
   const statsByType = MEDIA_TYPES.map((type) => {
     const typeEntries = entries.filter((e) => e.mediaItem.type === type);
@@ -78,47 +194,9 @@ export default async function DashboardPage() {
         ))}
       </div>
 
-      {/* In progress */}
-      {inProgress.length > 0 && (
-        <section>
-          <h2 className="text-lg font-semibold text-zinc-900 mb-3">Currently consuming</h2>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-            {inProgress.map((entry) => (
-              <MediaCard
-                key={entry.id}
-                id={entry.mediaItem.id}
-                title={entry.mediaItem.title}
-                year={entry.mediaItem.year}
-                posterUrl={entry.mediaItem.posterUrl}
-                mediaType={entry.mediaItem.type}
-                status={entry.status}
-                rating={entry.rating}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Recent completed */}
-      {recentCompleted.length > 0 && (
-        <section>
-          <h2 className="text-lg font-semibold text-zinc-900 mb-3">Recently completed</h2>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-            {recentCompleted.map((entry) => (
-              <MediaCard
-                key={entry.id}
-                id={entry.mediaItem.id}
-                title={entry.mediaItem.title}
-                year={entry.mediaItem.year}
-                posterUrl={entry.mediaItem.posterUrl}
-                mediaType={entry.mediaItem.type}
-                status={entry.status}
-                rating={entry.rating}
-              />
-            ))}
-          </div>
-        </section>
-      )}
+      <DashboardSection title="Currently Consuming" entries={inProgress} />
+      <DashboardSection title="Want to Consume" entries={wantEntries} showNextUp />
+      <DashboardSection title="Recently Consumed" entries={recentCompleted} />
 
       {entries.length === 0 && (
         <div className="flex flex-col items-center gap-4 py-20 text-center">

--- a/app/api/entries/[id]/promote/route.ts
+++ b/app/api/entries/[id]/promote/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const entry = await db.mediaEntry.findUnique({
+    where: { id },
+    include: { mediaItem: true },
+  });
+  if (!entry || entry.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Find the minimum sortOrder among WANT entries of the same media type for this user
+  const minResult = await db.mediaEntry.aggregate({
+    where: {
+      userId: session.user.id,
+      status: "WANT",
+      mediaItem: { type: entry.mediaItem.type },
+      id: { not: id },
+    },
+    _min: { sortOrder: true },
+  });
+
+  const currentMin = minResult._min.sortOrder ?? 0;
+  const newSortOrder = currentMin - 1;
+
+  const updated = await db.mediaEntry.update({
+    where: { id },
+    data: { sortOrder: newSortOrder },
+    include: { mediaItem: true },
+  });
+
+  return NextResponse.json(updated);
+}

--- a/components/media/SetNextUpButton.tsx
+++ b/components/media/SetNextUpButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface SetNextUpButtonProps {
+  entryId: string;
+  isNextUp: boolean;
+}
+
+export function SetNextUpButton({ entryId, isNextUp }: SetNextUpButtonProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  if (isNextUp) {
+    return (
+      <div className="flex items-center gap-1 rounded-full bg-amber-400 px-2 py-0.5 text-xs font-semibold text-amber-900">
+        <Star className="h-3 w-3 fill-amber-900" />
+        Next Up
+      </div>
+    );
+  }
+
+  async function handlePromote() {
+    setLoading(true);
+    await fetch(`/api/entries/${entryId}/promote`, { method: "POST" });
+    router.refresh();
+    setLoading(false);
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className="h-6 px-2 text-xs text-zinc-400 hover:text-amber-600"
+      disabled={loading}
+      onClick={handlePromote}
+    >
+      <Star className="h-3 w-3" />
+      Set Next
+    </Button>
+  );
+}

--- a/prisma/migrations/20260306000000_add_sort_order_to_media_entry/migration.sql
+++ b/prisma/migrations/20260306000000_add_sort_order_to_media_entry/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MediaEntry" ADD COLUMN "sortOrder" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,7 @@ model MediaEntry {
   rating      Float?
   reviewText  String?
   isPublic    Boolean     @default(true)
+  sortOrder   Int         @default(0)
   startedAt   DateTime?
   completedAt DateTime?
   createdAt   DateTime    @default(now())


### PR DESCRIPTION
## Summary

Closes #4

- Groups each dashboard section (Currently Consuming, Want to Consume, Recently Consumed) by media type category (Movies, TV Shows, Books, Audiobooks, Video Games) with visual sub-section dividers
- Adds the missing **Want to Consume** section to the dashboard
- Shows a **"Next Up"** amber badge on the first item in each Want category
- Adds a **"Set Next"** button on other Want items to promote them to the top of their category queue (persisted via `sortOrder` on `MediaEntry`)
- Adds `POST /api/entries/[id]/promote` endpoint that sets an entry's priority ahead of all others in the same media type + status group

## Database changes

New column: `MediaEntry.sortOrder INT NOT NULL DEFAULT 0` — migration included.

## Test plan

- [ ] Dashboard shows separate sub-sections per media type within each status group
- [ ] "Want to Consume" section appears and is grouped by type
- [ ] First card in each Want type group shows "Next Up" badge
- [ ] Clicking "Set Next" on a non-first card refreshes the page with that card promoted to first
- [ ] Sections with only one media type render a flat grid (no extra divider overhead)
- [ ] `prisma migrate deploy` applies the new migration cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)